### PR TITLE
공통 응답 및 예외 포맷 세팅 설정 

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -46,18 +46,18 @@ CREATE TABLE users
     nickname      VARCHAR(50)  NOT NULL,
     phone_number  VARCHAR(20)  NOT NULL UNIQUE,
     birth_date    DATE         NOT NULL,
-    gender        VARCHAR(5)      NOT NULL, # ENUM ('M', 'F')
+    gender        VARCHAR(5)   NOT NULL, # ENUM ('M', 'F')
     role          VARCHAR(20)  NOT NULL, # ENUM ('USER', 'SUPPLIER', 'ADMIN')
-    created_at DATETIME DEFAULT NOW(),
-    updated_at DATETIME DEFAULT NOW() ON UPDATE NOW()
+    created_at    DATETIME DEFAULT NOW(),
+    updated_at    DATETIME DEFAULT NOW() ON UPDATE NOW()
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;
 
 CREATE TABLE user_term_agreements
 (
-    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
-    user_id         BIGINT NOT NULL,
-    term_id         BIGINT NOT NULL,
+    id        BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id   BIGINT NOT NULL,
+    term_id   BIGINT NOT NULL,
     agreed_at DATETIME DEFAULT NOW(),
 
     FOREIGN KEY (user_id) REFERENCES users (id),
@@ -77,10 +77,11 @@ CREATE TABLE phone_verifications
     verification_code VARCHAR(5)  NOT NULL,
     attempt_count     INT         NOT NULL DEFAULT 0, # 인증 시도 횟수 (최대 3회 제한)
     is_verified       BOOLEAN     NOT NULL DEFAULT FALSE,
-    expired_at  DATETIME NOT NULL,
-    verified_at DATETIME NULL,
-    created_at  DATETIME DEFAULT NOW(),
-    updated_at  DATETIME DEFAULT NOW() ON UPDATE NOW(),
+    expired_at        DATETIME    NOT NULL,
+    verified_at       DATETIME    NULL,
+    last_sent_at      DATETIME    NOT NULL,
+    created_at        DATETIME             DEFAULT NOW(),
+    updated_at        DATETIME             DEFAULT NOW() ON UPDATE NOW(),
 
     UNIQUE KEY uk_phone_number (phone_number)
 ) ENGINE = InnoDB

--- a/reservation-admin-api/src/main/java/com/f1v3/reservation/admin/AdminReservationControllerAdvice.java
+++ b/reservation-admin-api/src/main/java/com/f1v3/reservation/admin/AdminReservationControllerAdvice.java
@@ -1,0 +1,51 @@
+package com.f1v3.reservation.admin;
+
+import com.f1v3.reservation.common.api.error.ErrorCode;
+import com.f1v3.reservation.common.api.error.ReservationException;
+import com.f1v3.reservation.common.api.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 관리자 서버 컨트롤러 어드바이스
+ *
+ * @author Seungjo, Jeong
+ */
+@RestControllerAdvice
+public class AdminReservationControllerAdvice {
+
+    @ExceptionHandler(ReservationException.class)
+    public ResponseEntity<ApiResponse<?>> handleReservationException(ReservationException e) {
+        ApiResponse<?> response = ApiResponse.error(e.getCode(), e.getMessage());
+
+        return ResponseEntity
+                .status(e.getStatus().getCode())
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST_PARAMETER;
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        ApiResponse<?> response = ApiResponse.error(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                errors
+        );
+
+        return ResponseEntity
+                .status(errorCode.getStatus().getCode())
+                .body(response);
+    }
+}

--- a/reservation-admin-api/src/main/java/com/f1v3/reservation/admin/term/TermService.java
+++ b/reservation-admin-api/src/main/java/com/f1v3/reservation/admin/term/TermService.java
@@ -3,6 +3,8 @@ package com.f1v3.reservation.admin.term;
 import com.f1v3.reservation.admin.term.dto.CreateTermRequest;
 import com.f1v3.reservation.admin.term.dto.CreateTermResponse;
 import com.f1v3.reservation.admin.term.dto.TermResponse;
+import com.f1v3.reservation.common.api.error.ErrorCode;
+import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.domain.term.Term;
 import com.f1v3.reservation.common.domain.term.dto.AdminTermDto;
 import com.f1v3.reservation.common.domain.term.enums.TermCode;
@@ -15,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_CODE_INVALID;
 
 /**
  * 관리자용 약관 서비스
@@ -39,7 +43,7 @@ public class TermService {
     @Transactional
     public CreateTermResponse create(CreateTermRequest request) {
         TermCode termCode = TermCode.getCode(request.code())
-                .orElseThrow(() -> new IllegalArgumentException("Invalid term code: " + request.code()));
+                .orElseThrow(() -> new ReservationException(TERM_CODE_INVALID));
 
         int nextVersion = termRepository.findMaxVersionByCode(termCode)
                 .map(version -> version + 1)
@@ -69,7 +73,7 @@ public class TermService {
             return termRepository.save(term);
         } catch (DataIntegrityViolationException e) {
             log.error("Term constraint violation: {}", e.getMessage());
-            throw new IllegalStateException("Term constraint violation", e);
+            throw new ReservationException(ErrorCode.TERM_VERSION_CONSTRAINT_VIOLATION);
         }
     }
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/ReservationControllerAdvice.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/ReservationControllerAdvice.java
@@ -1,0 +1,40 @@
+package com.f1v3.reservation.api;
+
+import com.f1v3.reservation.common.api.error.ErrorCode;
+import com.f1v3.reservation.common.api.error.ReservationException;
+import com.f1v3.reservation.common.api.response.ApiResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * API 예외 처리 컨트롤러 어드바이스
+ *
+ * @author Seungjo, Jeong
+ */
+@RestControllerAdvice
+public class ReservationControllerAdvice {
+
+    @ExceptionHandler(ReservationException.class)
+    public ApiResponse<?> handleReservationException(ReservationException e) {
+        return ApiResponse.error(e.getCode(), e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ApiResponse.error(
+                ErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
+                ErrorCode.INVALID_REQUEST_PARAMETER.getMessage(),
+                errors
+        );
+    }
+}

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/ReservationControllerAdvice.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/ReservationControllerAdvice.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * API 예외 처리 컨트롤러 어드바이스
+ * 사용자 서버 컨트롤러 어드바이스
  *
  * @author Seungjo, Jeong
  */

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/ReservationControllerAdvice.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/ReservationControllerAdvice.java
@@ -3,6 +3,7 @@ package com.f1v3.reservation.api;
 import com.f1v3.reservation.common.api.error.ErrorCode;
 import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.api.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,22 +20,30 @@ import java.util.Map;
 public class ReservationControllerAdvice {
 
     @ExceptionHandler(ReservationException.class)
-    public ApiResponse<?> handleReservationException(ReservationException e) {
-        return ApiResponse.error(e.getCode(), e.getMessage());
+    public ResponseEntity<ApiResponse<?>> handleReservationException(ReservationException e) {
+        return ResponseEntity
+                .status(e.getStatus().getCode())
+                .body(ApiResponse.error(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ApiResponse<?> handleArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<?>> handleArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        ErrorCode code = ErrorCode.INVALID_REQUEST_PARAMETER;
 
         Map<String, String> errors = new HashMap<>();
         e.getBindingResult().getFieldErrors().forEach(error ->
                 errors.put(error.getField(), error.getDefaultMessage())
         );
 
-        return ApiResponse.error(
+        ApiResponse<?> response = ApiResponse.error(
                 ErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
                 ErrorCode.INVALID_REQUEST_PARAMETER.getMessage(),
                 errors
         );
+
+        return ResponseEntity
+                .status(code.getStatus().getCode())
+                .body(response);
     }
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/phoneverification/strategy/ResendVerificationStrategy.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/phoneverification/strategy/ResendVerificationStrategy.java
@@ -1,5 +1,7 @@
 package com.f1v3.reservation.api.phoneverification.strategy;
 
+import com.f1v3.reservation.common.api.error.ErrorCode;
+import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.domain.phoneverification.PhoneVerification;
 import lombok.RequiredArgsConstructor;
 
@@ -20,11 +22,12 @@ public class ResendVerificationStrategy implements PhoneVerificationStrategy {
 
     @Override
     public PhoneVerification execute(String phoneNumber) {
-        boolean isResendAllowed = existingVerification.getCreatedAt().plusMinutes(RESEND_LIMIT_MINUTES)
+
+        boolean isResendAllowed = existingVerification.getLastSentAt().plusMinutes(RESEND_LIMIT_MINUTES)
                 .isBefore(LocalDateTime.now());
 
         if (!isResendAllowed) {
-            throw new IllegalArgumentException(RESEND_LIMIT_MINUTES + "분 이내에 생성한 인증 요청이 존재합니다.");
+            throw new ReservationException(ErrorCode.PHONE_VERIFICATION_RESEND_NOT_ALLOWED);
         }
 
         existingVerification.resend(newCode);

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/term/TermValidationService.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/term/TermValidationService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_CODE_NOT_FOUND;
+import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_CODE_INVALID;
 import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_REQUIRED_NOT_AGREED;
 
 /**
@@ -32,7 +32,7 @@ public class TermValidationService {
 
         Set<TermCode> agreedTermIds = termRequests.stream()
                 .map(request -> TermCode.getCode(request.termCode())
-                        .orElseThrow(() -> new ReservationException(TERM_CODE_NOT_FOUND))
+                        .orElseThrow(() -> new ReservationException(TERM_CODE_INVALID))
                 )
                 .collect(Collectors.toSet());
 

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/term/TermValidationService.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/term/TermValidationService.java
@@ -2,12 +2,16 @@ package com.f1v3.reservation.api.term;
 
 import com.f1v3.reservation.api.term.dto.TermResponse;
 import com.f1v3.reservation.api.user.dto.SignupUserRequest;
+import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.domain.term.enums.TermCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_CODE_NOT_FOUND;
+import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_REQUIRED_NOT_AGREED;
 
 /**
  * 회원가입 약관 동의 검증 서비스
@@ -28,13 +32,14 @@ public class TermValidationService {
 
         Set<TermCode> agreedTermIds = termRequests.stream()
                 .map(request -> TermCode.getCode(request.termCode())
-                        .orElseThrow(() -> new IllegalArgumentException("Invalid termCode: " + request.termCode())))
+                        .orElseThrow(() -> new ReservationException(TERM_CODE_NOT_FOUND))
+                )
                 .collect(Collectors.toSet());
 
         requiredTermIds.removeAll(agreedTermIds);
 
         if (!requiredTermIds.isEmpty()) {
-            throw new IllegalArgumentException("필수 약관에 모두 동의해야 합니다. 누락된 약관 id=" + requiredTermIds);
+            throw new ReservationException(TERM_REQUIRED_NOT_AGREED);
         }
     }
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/user/UserTermAgreementService.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/user/UserTermAgreementService.java
@@ -2,6 +2,7 @@ package com.f1v3.reservation.api.user;
 
 import com.f1v3.reservation.api.term.TermValidationService;
 import com.f1v3.reservation.api.user.dto.SignupUserRequest;
+import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.domain.term.Term;
 import com.f1v3.reservation.common.domain.term.enums.TermCode;
 import com.f1v3.reservation.common.domain.term.repository.TermRepository;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
+
+import static com.f1v3.reservation.common.api.error.ErrorCode.TERM_NOT_FOUND;
 
 /**
  * 사용자 약관 동의 서비스 클래스
@@ -41,10 +44,10 @@ public class UserTermAgreementService {
 
     private UserTermAgreement createAgreement(User user, SignupUserRequest.SignupTermRequest request) {
         TermCode termCode = TermCode.getCode(request.termCode())
-                .orElseThrow(() -> new IllegalArgumentException("Invalid termCode: " + request.termCode()));
+                .orElseThrow(() -> new ReservationException(TERM_NOT_FOUND));
 
         Term term = termRepository.findByCodeAndVersion(termCode, request.version())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 약관입니다. termCode=" + request.termCode() + ", version=" + request.version()));
+                .orElseThrow(() -> new ReservationException(TERM_NOT_FOUND));
 
         return UserTermAgreement.builder()
                 .user(user)

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/user/UserValidationService.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/user/UserValidationService.java
@@ -1,8 +1,12 @@
 package com.f1v3.reservation.api.user;
 
+import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.f1v3.reservation.common.api.error.ErrorCode.USER_EMAIL_ALREADY_EXISTS;
+import static com.f1v3.reservation.common.api.error.ErrorCode.USER_PHONE_ALREADY_EXISTS;
 
 /**
  * 회원 검증 서비스
@@ -17,13 +21,13 @@ public class UserValidationService {
 
     public void checkPhoneNumberExists(String phoneNumber) {
         if (userRepository.existsByPhoneNumber(phoneNumber)) {
-            throw new IllegalArgumentException("이미 가입된 핸드폰 번호입니다.");
+            throw new ReservationException(USER_PHONE_ALREADY_EXISTS);
         }
     }
 
     public void checkEmailExists(String email) {
         if (userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+            throw new ReservationException(USER_EMAIL_ALREADY_EXISTS);
         }
     }
 }

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -18,17 +18,26 @@ public enum ErrorCode {
     /*
     약관(Term) [code: 41xx]
      */
-
+    TERM_NOT_FOUND(4101, "약관을 찾을 수 없습니다."),
+    TERM_CODE_NOT_FOUND(4102, "올바르지 않은 약관 코드입니다."),
+    TERM_REQUIRED_NOT_AGREED(4103, "필수 약관에 동의하지 않았습니다."),
 
     /*
     핸드폰 인증(PhoneVerification) [code: 42xx]
      */
-
+    PHONE_VERIFICATION_NOT_FOUND(4201, "핸드폰 인증 정보를 찾을 수 없습니다."),
+    PHONE_VERIFICATION_CODE_EXPIRED(4202, "인증번호가 만료되었습니다."),
+    PHONE_VERIFICATION_CODE_INVALID(4203, "인증번호가 올바르지 않습니다."),
+    PHONE_VERIFICATION_ALREADY_VERIFIED(4204, "이미 인증된 핸드폰 번호입니다."),
+    PHONE_VERIFICATION_ATTEMPTS_EXCEEDED(4205, "인증 시도 횟수를 초과했습니다."),
+    PHONE_VERIFICATION_NOT_VERIFIED(4207, "핸드폰 인증이 완료되지 않았습니다."),
+    PHONE_VERIFICATION_INFO_EXPIRED(4208, "핸드폰 인증 정보가 만료되었습니다."),
 
     /*
     회원(User) [code: 43xx]
      */
-
+    USER_EMAIL_ALREADY_EXISTS(4301, "이미 등록된 이메일입니다."),
+    USER_PHONE_ALREADY_EXISTS(4302, "이미 등록된 핸드폰 번호입니다."),
 
     /*
     서버 에러 정의

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     TERM_CODE_INVALID(ErrorStatus.BAD_REQUEST, 4102, "올바르지 않은 약관 코드입니다."),
     TERM_REQUIRED_NOT_AGREED(ErrorStatus.BAD_REQUEST, 4103, "필수 약관에 동의하지 않았습니다."),
     TERM_VERSION_CONSTRAINT_VIOLATION(ErrorStatus.CONFLICT, 4104, "약관 생성 시 버전 충돌이 발생했습니다. 버전을 확인해주세요."),
+    TERM_REQUIRED_DISPLAY_ORDER_INVALID(ErrorStatus.BAD_REQUEST, 4105, "필수 약관의 표시 순서는 0 ~ 500 사이의 값이어야 합니다."),
+    TERM_OPTIONAL_DISPLAY_ORDER_INVALID(ErrorStatus.BAD_REQUEST, 4106, "선택 약관의 표시 순서는 501 ~ 1000 사이의 값이어야 합니다."),
 
     /*
     핸드폰 인증(PhoneVerification) [code: 42xx]

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -10,48 +10,49 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-
     /*
     공통 에러 정의 [code: 1xxx]
      */
-    INVALID_REQUEST_PARAMETER(1000, "요청 값이 올바르지 않습니다. 요청 값을 확인해주세요."),
+    INVALID_REQUEST_PARAMETER(ErrorStatus.BAD_REQUEST, 1000, "요청 값이 올바르지 않습니다. 요청 값을 확인해주세요."),
 
     /*
     약관(Term) [code: 41xx]
      */
-    TERM_NOT_FOUND(4101, "약관을 찾을 수 없습니다."),
-    TERM_CODE_INVALID(4102, "올바르지 않은 약관 코드입니다."),
-    TERM_REQUIRED_NOT_AGREED(4103, "필수 약관에 동의하지 않았습니다."),
-    TERM_VERSION_CONSTRAINT_VIOLATION(4104, "약관 생성 시 버전 충돌이 발생했습니다. 버전을 확인해주세요."),
+    TERM_NOT_FOUND(ErrorStatus.NOT_FOUND, 4101, "약관을 찾을 수 없습니다."),
+    TERM_CODE_INVALID(ErrorStatus.BAD_REQUEST, 4102, "올바르지 않은 약관 코드입니다."),
+    TERM_REQUIRED_NOT_AGREED(ErrorStatus.BAD_REQUEST, 4103, "필수 약관에 동의하지 않았습니다."),
+    TERM_VERSION_CONSTRAINT_VIOLATION(ErrorStatus.CONFLICT, 4104, "약관 생성 시 버전 충돌이 발생했습니다. 버전을 확인해주세요."),
 
     /*
     핸드폰 인증(PhoneVerification) [code: 42xx]
      */
-    PHONE_VERIFICATION_NOT_FOUND(4201, "핸드폰 인증 정보를 찾을 수 없습니다."),
-    PHONE_VERIFICATION_CODE_EXPIRED(4202, "인증번호가 만료되었습니다."),
-    PHONE_VERIFICATION_CODE_INVALID(4203, "인증번호가 올바르지 않습니다."),
-    PHONE_VERIFICATION_ALREADY_VERIFIED(4204, "이미 인증된 핸드폰 번호입니다."),
-    PHONE_VERIFICATION_ATTEMPTS_EXCEEDED(4205, "인증 시도 횟수를 초과했습니다."),
-    PHONE_VERIFICATION_NOT_VERIFIED(4207, "핸드폰 인증이 완료되지 않았습니다."),
-    PHONE_VERIFICATION_INFO_EXPIRED(4208, "핸드폰 인증 정보가 만료되었습니다."),
-    PHONE_VERIFICATION_RESEND_NOT_ALLOWED(4209, "인증번호 재전송은 3분 후에 가능합니다."),
+    PHONE_VERIFICATION_NOT_FOUND(ErrorStatus.NOT_FOUND, 4201, "핸드폰 인증 정보를 찾을 수 없습니다."),
+    PHONE_VERIFICATION_CODE_EXPIRED(ErrorStatus.BAD_REQUEST, 4202, "인증번호가 만료되었습니다."),
+    PHONE_VERIFICATION_CODE_INVALID(ErrorStatus.BAD_REQUEST, 4203, "인증번호가 올바르지 않습니다."),
+    PHONE_VERIFICATION_ALREADY_VERIFIED(ErrorStatus.CONFLICT, 4204, "이미 인증된 핸드폰 번호입니다."),
+    PHONE_VERIFICATION_ATTEMPTS_EXCEEDED(ErrorStatus.BAD_REQUEST, 4205, "인증 시도 횟수를 초과했습니다."),
+    PHONE_VERIFICATION_NOT_VERIFIED(ErrorStatus.BAD_REQUEST, 4207, "핸드폰 인증이 완료되지 않았습니다."),
+    PHONE_VERIFICATION_INFO_EXPIRED(ErrorStatus.BAD_REQUEST, 4208, "핸드폰 인증 정보가 만료되었습니다."),
+    PHONE_VERIFICATION_RESEND_NOT_ALLOWED(ErrorStatus.BAD_REQUEST, 4209, "인증번호 재전송은 3분 후에 가능합니다."),
 
     /*
     회원(User) [code: 43xx]
      */
-    USER_EMAIL_ALREADY_EXISTS(4301, "이미 등록된 이메일입니다."),
-    USER_PHONE_ALREADY_EXISTS(4302, "이미 등록된 핸드폰 번호입니다."),
+    USER_EMAIL_ALREADY_EXISTS(ErrorStatus.CONFLICT, 4301, "이미 등록된 이메일입니다."),
+    USER_PHONE_ALREADY_EXISTS(ErrorStatus.CONFLICT, 4302, "이미 등록된 핸드폰 번호입니다."),
 
     /*
     서버 에러 정의
      */
-    SERVER_ERROR(5000, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    SERVER_ERROR(ErrorStatus.INTERNAL_SERVER_ERROR, 5000, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
     ;
 
+    private final ErrorStatus status;
     private final int code;
     private final String message;
 
-    ErrorCode(int code, String message) {
+    ErrorCode(ErrorStatus status, int code, String message) {
+        this.status = status;
         this.code = code;
         this.message = message;
     }

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -11,16 +11,17 @@ import lombok.Getter;
 public enum ErrorCode {
 
     /*
-    공통 에러 정의
+    공통 에러 정의 [code: 1xxx]
      */
-    INVALID_REQUEST_PARAMETER(4000, "요청 값이 올바르지 않습니다. 요청 값을 확인해주세요."),
+    INVALID_REQUEST_PARAMETER(1000, "요청 값이 올바르지 않습니다. 요청 값을 확인해주세요."),
 
     /*
     약관(Term) [code: 41xx]
      */
     TERM_NOT_FOUND(4101, "약관을 찾을 수 없습니다."),
-    TERM_CODE_NOT_FOUND(4102, "올바르지 않은 약관 코드입니다."),
+    TERM_CODE_INVALID(4102, "올바르지 않은 약관 코드입니다."),
     TERM_REQUIRED_NOT_AGREED(4103, "필수 약관에 동의하지 않았습니다."),
+    TERM_VERSION_CONSTRAINT_VIOLATION(4104, "약관 생성 시 버전 충돌이 발생했습니다. 버전을 확인해주세요."),
 
     /*
     핸드폰 인증(PhoneVerification) [code: 42xx]

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
+
     /*
     공통 에러 정의 [code: 1xxx]
      */
@@ -33,6 +34,7 @@ public enum ErrorCode {
     PHONE_VERIFICATION_ATTEMPTS_EXCEEDED(4205, "인증 시도 횟수를 초과했습니다."),
     PHONE_VERIFICATION_NOT_VERIFIED(4207, "핸드폰 인증이 완료되지 않았습니다."),
     PHONE_VERIFICATION_INFO_EXPIRED(4208, "핸드폰 인증 정보가 만료되었습니다."),
+    PHONE_VERIFICATION_RESEND_NOT_ALLOWED(4209, "인증번호 재전송은 3분 후에 가능합니다."),
 
     /*
     회원(User) [code: 43xx]
@@ -53,4 +55,4 @@ public enum ErrorCode {
         this.code = code;
         this.message = message;
     }
-    }
+}

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -1,0 +1,46 @@
+package com.f1v3.reservation.common.api.error;
+
+import lombok.Getter;
+
+/**
+ * API 공통 에러 코드 ENUM
+ *
+ * @author Seungjo, Jeong
+ */
+@Getter
+public enum ErrorCode {
+
+    /*
+    공통 에러 정의
+     */
+    INVALID_REQUEST_PARAMETER(4000, "요청 값이 올바르지 않습니다. 요청 값을 확인해주세요."),
+
+    /*
+    약관(Term) [code: 41xx]
+     */
+
+
+    /*
+    핸드폰 인증(PhoneVerification) [code: 42xx]
+     */
+
+
+    /*
+    회원(User) [code: 43xx]
+     */
+
+
+    /*
+    서버 에러 정의
+     */
+    SERVER_ERROR(5000, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    ;
+
+    private final int code;
+    private final String message;
+
+    ErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+    }

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorStatus.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorStatus.java
@@ -1,0 +1,26 @@
+package com.f1v3.reservation.common.api.error;
+
+import lombok.Getter;
+
+/**
+ * HTTP 에러 상태 코드
+ *
+ * @author Seungjo, Jeong
+ */
+@Getter
+public enum ErrorStatus {
+
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+    METHOD_NOT_ALLOWED(405),
+    CONFLICT(409),
+    INTERNAL_SERVER_ERROR(500);
+
+    private final int code;
+
+    ErrorStatus(int code) {
+        this.code = code;
+    }
+}

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ReservationException.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ReservationException.java
@@ -1,0 +1,21 @@
+package com.f1v3.reservation.common.api.error;
+
+import lombok.Getter;
+
+/**
+ * 공통 예외 최상위 클래스
+ *
+ * @author Seungjo, Jeong
+ */
+@Getter
+public class ReservationException extends RuntimeException {
+    private final int code;
+    private final String message;
+
+    public ReservationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}
+

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ReservationException.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ReservationException.java
@@ -9,13 +9,14 @@ import lombok.Getter;
  */
 @Getter
 public class ReservationException extends RuntimeException {
+    private final ErrorStatus status;
     private final int code;
     private final String message;
 
     public ReservationException(ErrorCode errorCode) {
         super(errorCode.getMessage());
+        this.status = errorCode.getStatus();
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
     }
 }
-

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/response/ApiResponse.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/response/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.f1v3.reservation.common.api.response;
+
+/**
+ * API 공통 응답 클래스
+ *
+ * @author Seungjo, Jeong
+ */
+public record ApiResponse<T>(
+        int code,
+        String message,
+        T content
+) {
+    public static <T> ApiResponse<T> success(T content) {
+        return new ApiResponse<>(0, null, content);
+    }
+
+    public static <T> ApiResponse<T> error(int code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
+
+    public static <T> ApiResponse<T> error(int code, String message, T content) {
+        return new ApiResponse<>(code, message, content);
+    }
+}

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/domain/phoneverification/PhoneVerification.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/domain/phoneverification/PhoneVerification.java
@@ -46,6 +46,9 @@ public class PhoneVerification extends BaseEntity {
     @Column(nullable = true)
     private LocalDateTime verifiedAt;
 
+    @Column(nullable = false)
+    private LocalDateTime lastSentAt;
+
     @Builder
     public PhoneVerification(String phoneNumber, String verificationCode) {
         this.phoneNumber = phoneNumber;
@@ -53,6 +56,7 @@ public class PhoneVerification extends BaseEntity {
         this.attemptCount = 0;
         this.isVerified = false;
         this.expiredAt = LocalDateTime.now().plusMinutes(VERIFICATION_EXPIRY_MINUTES);
+        this.lastSentAt = LocalDateTime.now();
     }
 
     public boolean isExpired() {
@@ -81,6 +85,7 @@ public class PhoneVerification extends BaseEntity {
         this.isVerified = false;
         this.expiredAt = LocalDateTime.now().plusMinutes(VERIFICATION_EXPIRY_MINUTES);
         this.verifiedAt = null;
+        this.lastSentAt = LocalDateTime.now();
     }
 
     public void verify() {

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/domain/term/Term.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/domain/term/Term.java
@@ -1,5 +1,7 @@
 package com.f1v3.reservation.common.domain.term;
 
+import com.f1v3.reservation.common.api.error.ErrorCode;
+import com.f1v3.reservation.common.api.error.ReservationException;
 import com.f1v3.reservation.common.domain.BaseEntity;
 import com.f1v3.reservation.common.domain.term.enums.TermCode;
 import jakarta.persistence.*;
@@ -71,11 +73,11 @@ public class Term extends BaseEntity {
     private void validateDisplayOrder() {
         if (Boolean.TRUE.equals(isRequired)) {
             if (displayOrder < 0 || displayOrder > 500) {
-                throw new IllegalArgumentException("필수 약관의 displayOrder는 0에서 500 사이여야 합니다.");
+                throw new ReservationException(ErrorCode.TERM_REQUIRED_DISPLAY_ORDER_INVALID);
             }
         } else {
             if (displayOrder < 501 || displayOrder > 1000) {
-                throw new IllegalArgumentException("선택 약관의 displayOrder는 501에서 1000 사이여야 합니다.");
+                throw new ReservationException(ErrorCode.TERM_OPTIONAL_DISPLAY_ORDER_INVALID);
             }
         }
     }


### PR DESCRIPTION
## 연관 이슈

resolves #6 

## 작업 내용

### Common Module

- 공통 응답 정의 (`ApiResponse`)
- 공통 에러 정의 (`ErrorCode`, `ErrorStatus`, `ReservationException`) 

### API Module

- api module: `ReservationControllerAdvice` 
- admin-api module: `AdminReservationControllerAdvice`
- 기존 사용하던 예외(`IllegalArgumentException, IllegalStateException`)를 커스텀 예외(`ReservationException`)으로 처리하여 ControllerAdvice에서 공통 처리 
