### PR TITLE
가계약 생성 로직 수정 

### DIFF
--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/ReservationHoldFacade.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/ReservationHoldFacade.java
@@ -136,7 +136,7 @@ public class ReservationHoldFacade {
             throw new ReservationException(INVALID_REQUEST_PARAMETER, log::info, parameters);
         }
 
-        if (checkIn.plusDays(30).isAfter(checkOut)) {
+        if (checkOut.minusDays(30).isAfter(checkIn)) {
             Map<String, Object> parameters = Map.of("checkIn", checkIn, "checkOut", checkOut);
             throw new ReservationException(RESERVATION_MAX_STAY_EXCEEDED, log::info, parameters);
         }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/ReservationHoldService.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/ReservationHoldService.java
@@ -2,9 +2,8 @@ package com.f1v3.reservation.api.reservation;
 
 import com.f1v3.reservation.api.reservation.cache.ReservationHoldCache;
 import com.f1v3.reservation.api.reservation.cache.ReservationHoldCountCache;
-import com.f1v3.reservation.api.reservation.cache.ReservationHoldIdempotencyCache;
 import com.f1v3.reservation.api.reservation.cache.ReservationHoldIndexCache;
-import com.f1v3.reservation.api.reservation.dto.ConfirmReservationHoldResponse;
+import com.f1v3.reservation.api.reservation.cache.ReservationHoldRequestKeyCache;
 import com.f1v3.reservation.api.reservation.dto.CreateReservationHoldRequest;
 import com.f1v3.reservation.api.reservation.dto.ReservationHoldResponse;
 import com.f1v3.reservation.common.api.error.ReservationException;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,16 +32,21 @@ import static com.f1v3.reservation.common.api.error.ErrorCode.*;
 @RequiredArgsConstructor
 public class ReservationHoldService {
 
-    //    private static final Duration HOLD_EXPIRE_MINUTES = Duration.ofMinutes(10);
-    private static final Duration HOLD_EXPIRE_MINUTES = Duration.ofMinutes(1);
+    private static final Duration HOLD_EXPIRE_MINUTES = Duration.ofMinutes(10);
 
     private final ReservationHoldCache holdCache;
     private final ReservationHoldIndexCache indexCache;
-    private final ReservationHoldIdempotencyCache idempotencyCache;
+    private final ReservationHoldRequestKeyCache holdRequestKeyCache;
     private final ReservationHoldCountCache countCache;
 
     /**
-     * 가계약 생성 후 Redis JSON 저장 (TTL 기반, 만료 배치 없이 처리)
+     * 가계약 및 관련 캐시 생성
+     * 1. 기존 가계약 정리 (같은 사용자가 동일 객실타입/기간으로 가계약을 여러개 생성하는 경우 방지)
+     * 2. 가계약 생성
+     * 3. 요청 키 확인 (중복 요청 방지)
+     * 4. 가계약 저장 및 인덱스/요청키/카운트 캐시 생성
+     *
+     * @return 생성된 가계약 ID 및 만료 시각
      */
     public ReservationHoldResponse createHold(Long userId, RoomType roomType, CreateReservationHoldRequest request) {
         LocalDateTime now = LocalDateTime.now();
@@ -64,44 +67,68 @@ public class ReservationHoldService {
                 checkIn,
                 checkOut,
                 userId,
-                request.idempotencyKey(),
+                request.holdRequestKey(),
                 now,
                 expiredAt
         );
 
-        // 3. 멱등키 확인 (중복 요청 방지)
-        checkIdempotencyKeyAvailable(request.idempotencyKey(), roomType.getId(), checkIn, checkOut, holdId);
+        // 3. 요청 키 확인 (중복 요청 방지)
+        checkHoldRequestKeyAvailable(request.holdRequestKey(), roomType.getId(), checkIn, checkOut, holdId);
 
-        // fixme: 하나의 Lua Script로 처리하여 라운드 트립을 1회로 만들기
-        //  (장애 발생시 정합성을 보장하는 방안을 고려해야 함.)
         holdCache.save(hold, HOLD_EXPIRE_MINUTES);
         indexCache.save(userId, roomType.getId(), checkIn, checkOut, holdId, HOLD_EXPIRE_MINUTES);
-        idempotencyCache.save(request.idempotencyKey(), holdId, roomType.getId(), checkIn, checkOut, HOLD_EXPIRE_MINUTES);
+        holdRequestKeyCache.save(request.holdRequestKey(), holdId, roomType.getId(), checkIn, checkOut, HOLD_EXPIRE_MINUTES);
         stayDays.forEach(day -> countCache.increment(roomType.getId(), day, HOLD_EXPIRE_MINUTES));
 
         return new ReservationHoldResponse(holdId, expiredAt);
     }
 
-    public ConfirmReservationHoldResponse confirmReservationHold(String holdId, Long userId) {
-        ReservationHold hold = getCacheOrThrowIfProcessed(holdId);
-        validateHold(hold, userId);
-        ensureHoldNotProcessed(hold);
+    public Map<LocalDate, Long> getHoldCounts(Long roomTypeId, List<LocalDate> stayDays) {
+        return countCache.getCounts(roomTypeId, stayDays);
+    }
 
+    /**
+     * 락 만료 등으로 가계약을 무효화해야 할 때, holdId 기준으로 안전하게 정리한다.
+     */
+    public void cleanup(String holdId) {
+        ReservationHold hold = holdCache.find(holdId).orElse(null);
+        if (hold == null) {
+            return;
+        }
+
+        cleanupHoldCounts(hold);
+        holdCache.delete(hold.holdId());
+        deleteIndexIfMatch(hold);
+        deleteRequestKeyIfMatch(hold);
+    }
+
+    private void cleanupHoldCounts(ReservationHold hold) {
         stayDays(hold.checkIn(), hold.checkOut())
                 .forEach(day -> countCache.decrement(hold.roomTypeId(), day, HOLD_EXPIRE_MINUTES));
-
-        deleteAllKeys(hold);
-
-        return new ConfirmReservationHoldResponse(holdId, hold.roomTypeId(), hold.checkIn(), hold.checkOut(), 1);
     }
 
-    public Map<LocalDate, Long> getHoldCounts(Long roomTypeId, List<LocalDate> stayDays) {
-        Map<LocalDate, Long> counts = new HashMap<>();
-        for (LocalDate day : stayDays) {
-            counts.put(day, countCache.get(roomTypeId, day));
-        }
-        return counts;
+    private void deleteIndexIfMatch(ReservationHold hold) {
+        indexCache.findHoldId(hold.userId(), hold.roomTypeId(), hold.checkIn(), hold.checkOut())
+                .filter(hold.holdId()::equals)
+                .ifPresent(existingHoldId -> indexCache.delete(
+                        hold.userId(),
+                        hold.roomTypeId(),
+                        hold.checkIn(),
+                        hold.checkOut()
+                ));
     }
+
+    private void deleteRequestKeyIfMatch(ReservationHold hold) {
+        holdRequestKeyCache.find(hold.holdRequestKey(), hold.roomTypeId(), hold.checkIn(), hold.checkOut())
+                .filter(hold.holdId()::equals)
+                .ifPresent(existingHoldId -> holdRequestKeyCache.delete(
+                        hold.holdRequestKey(),
+                        hold.roomTypeId(),
+                        hold.checkIn(),
+                        hold.checkOut()
+                ));
+    }
+
 
     private void cleanupExistingHold(String holdId, Long roomTypeId, Long userId, LocalDate checkIn, LocalDate checkOut) {
         holdCache.find(holdId).ifPresentOrElse(
@@ -118,11 +145,6 @@ public class ReservationHoldService {
         );
     }
 
-    private ReservationHold getCacheOrThrowIfProcessed(String holdId) {
-        return holdCache.find(holdId)
-                .orElseThrow(() -> new ReservationException(RESERVATION_HOLD_ALREADY_PROCESSED, log::info));
-    }
-
     private void validateHold(ReservationHold hold, Long userId) {
         if (!hold.userId().equals(userId)) {
             throw new ReservationException(RESERVATION_HOLD_FORBIDDEN, log::warn);
@@ -134,54 +156,44 @@ public class ReservationHoldService {
         }
     }
 
-    private void ensureHoldNotProcessed(ReservationHold hold) {
-        List<LocalDate> stayDays = stayDays(hold.checkIn(), hold.checkOut());
-        for (LocalDate day : stayDays) {
-            long count = countCache.get(hold.roomTypeId(), day);
-            if (count <= 0) {
-                cleanupHoldCounts(hold);
-                deleteAllKeys(hold);
-                throw new ReservationException(RESERVATION_HOLD_ALREADY_PROCESSED, log::info);
-            }
-        }
-    }
+    private void checkHoldRequestKeyAvailable(
+            String holdRequestKey,
+            Long roomTypeId,
+            LocalDate checkIn,
+            LocalDate checkOut,
+            String holdId
+    ) {
 
-    private void checkIdempotencyKeyAvailable(String key, Long roomTypeId, LocalDate checkIn, LocalDate checkOut, String holdId) {
-
-        // 1. 멱등 키가 없으면 저장하고 종료
-        if (idempotencyCache.setIfAbsent(key, roomTypeId, checkIn, checkOut, holdId, HOLD_EXPIRE_MINUTES)) {
+        // 1. 요청 키가 없으면 저장하고 종료
+        if (holdRequestKeyCache.setIfAbsent(holdRequestKey, roomTypeId, checkIn, checkOut, holdId, HOLD_EXPIRE_MINUTES)) {
             return;
         }
 
-        // 2. 이미 멱등키가 존재하는 경우: (멱등키 -> holdId) 매핑 정합성 확인
-        String existingHoldId = idempotencyCache.find(key, roomTypeId, checkIn, checkOut)
+        // 2. 이미 요청 키가 존재하는 경우: (요청 키 -> holdId) 매핑 정합성 확인
+        String existingHoldId = holdRequestKeyCache.find(holdRequestKey, roomTypeId, checkIn, checkOut)
                 .orElseGet(() -> {
-                    // 멱등키는 있는데 holdId가 없는 경우: 캐시 정합성 문제로 간주하고 멱등키 삭제 후 예외 발생
-                    idempotencyCache.delete(key, roomTypeId, checkIn, checkOut);
+                    // 요청 키는 있는데 holdId가 없는 경우: 캐시 정합성 문제로 간주하고 요청 키 삭제 후 예외 발생
+                    holdRequestKeyCache.delete(holdRequestKey, roomTypeId, checkIn, checkOut);
                     throw new ReservationException(RESERVATION_HOLD_NOT_FOUND, log::info);
                 });
 
-        // 3. 멱등키가 가리키는 holdId가 존재하는 경우: 중복 요청 처리 (예외?)
+        // 3. 요청 키가 가리키는 holdId가 존재하는 경우: 중복 요청 처리 (409 예외)
         if (holdCache.find(existingHoldId).isPresent()) {
-            throw new ReservationException(RESERVATION_HOLD_KEY_CONFLICT, log::info);
+            throw new ReservationException(RESERVATION_HOLD_REQUEST_KEY_CONFLICT, log::info);
         }
 
-        // 4. 멱등키는 있는데 holdId가 없는 경우: 캐시 정합성 문제로 간주하고 멱등키 삭제 후 예외 발생
-        idempotencyCache.delete(key, roomTypeId, checkIn, checkOut);
+        // 4. 요청 키는 있는데 holdId가 없는 경우: 캐시 정합성 문제로 간주하고 요청 키 삭제 후 예외 발생
+        holdRequestKeyCache.delete(holdRequestKey, roomTypeId, checkIn, checkOut);
         throw new ReservationException(RESERVATION_HOLD_NOT_FOUND, log::info);
     }
-    private void cleanupHoldCounts(ReservationHold hold) {
-        stayDays(hold.checkIn(), hold.checkOut())
-                .forEach(day -> countCache.delete(hold.roomTypeId(), day));
+
+    private List<LocalDate> stayDays(LocalDate checkIn, LocalDate checkOut) {
+        return checkIn.datesUntil(checkOut.plusDays(1)).toList();
     }
 
     private void deleteAllKeys(ReservationHold hold) {
         holdCache.delete(hold.holdId());
         indexCache.delete(hold.userId(), hold.roomTypeId(), hold.checkIn(), hold.checkOut());
-        idempotencyCache.delete(hold.idempotencyKey(), hold.roomTypeId(), hold.checkIn(), hold.checkOut());
-    }
-
-    private List<LocalDate> stayDays(LocalDate checkIn, LocalDate checkOut) {
-        return checkIn.datesUntil(checkOut).toList();
+        holdRequestKeyCache.delete(hold.holdRequestKey(), hold.roomTypeId(), hold.checkIn(), hold.checkOut());
     }
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldCountCache.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldCountCache.java
@@ -73,8 +73,9 @@ public class ReservationHoldCountCache {
 
         Map<LocalDate, Long> counts = HashMap.newHashMap(stayDays.size());
         for (int i = 0; i < stayDays.size(); i++) {
-            String count = values.get(i);
-            counts.put(stayDays.get(i), Long.parseLong(count));
+            String value = values.get(i);
+            long count = value == null ? 0L : Long.parseLong(value);
+            counts.put(stayDays.get(i), count);
         }
         return counts;
     }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldCountCache.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldCountCache.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 가계약 보유 카운트 캐시
@@ -60,5 +63,19 @@ public class ReservationHoldCountCache {
 
     private String countKey(Long roomTypeId, LocalDate day) {
         return String.format(com.f1v3.reservation.common.redis.RedisKey.HOLD_COUNT_FORMAT, roomTypeId, day);
+    }
+
+    public Map<LocalDate, Long> getCounts(Long roomTypeId, List<LocalDate> stayDays) {
+        List<String> keys = stayDays.stream()
+                .map(day -> countKey(roomTypeId, day))
+                .toList();
+        List<String> values = redisRepository.getMultiValues(keys);
+
+        Map<LocalDate, Long> counts = HashMap.newHashMap(stayDays.size());
+        for (int i = 0; i < stayDays.size(); i++) {
+            String count = values.get(i);
+            counts.put(stayDays.get(i), Long.parseLong(count));
+        }
+        return counts;
     }
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldIdempotencyCache.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldIdempotencyCache.java
@@ -19,7 +19,7 @@ import static com.f1v3.reservation.common.redis.RedisKey.HOLD_IDEMPOTENT_FORMAT;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ReservationHoldIdempotentCache {
+public class ReservationHoldIdempotencyCache {
 
     private final RedisRepository redisRepository;
 

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldRequestKeyCache.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/cache/ReservationHoldRequestKeyCache.java
@@ -9,66 +9,66 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Optional;
 
-import static com.f1v3.reservation.common.redis.RedisKey.HOLD_IDEMPOTENT_FORMAT;
+import static com.f1v3.reservation.common.redis.RedisKey.HOLD_REQUEST_KEY_FORMAT;
 
 /**
- * 가계약의 멱등 키 캐시
+ * 가계약 요청 키 캐시
  *
  * @author Seungjo, Jeong
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ReservationHoldIdempotencyCache {
+public class ReservationHoldRequestKeyCache {
 
     private final RedisRepository redisRepository;
 
     public boolean setIfAbsent(
-            String idempotentKey,
+            String holdRequestKey,
             Long roomTypeId,
             LocalDate checkIn,
             LocalDate checkOut,
             String holdId,
             Duration ttl
     ) {
-        String key = idempotentKey(idempotentKey, roomTypeId, checkIn, checkOut);
+        String key = holdRequestKeyCacheKey(holdRequestKey, roomTypeId, checkIn, checkOut);
         Boolean result = redisRepository.setIfAbsent(key, holdId, ttl);
         return Boolean.TRUE.equals(result);
     }
 
     public Optional<String> find(
-            String idempotentKey,
+            String holdRequestKey,
             Long roomTypeId,
             LocalDate checkIn,
             LocalDate checkOut
     ) {
-        String key = idempotentKey(idempotentKey, roomTypeId, checkIn, checkOut);
+        String key = holdRequestKeyCacheKey(holdRequestKey, roomTypeId, checkIn, checkOut);
         return Optional.ofNullable(redisRepository.getValue(key));
     }
 
     public void save(
-            String idempotentKey,
+            String holdRequestKey,
             String holdId,
             Long roomTypeId,
             LocalDate checkIn,
             LocalDate checkOut,
             Duration ttl
     ) {
-        String key = idempotentKey(idempotentKey, roomTypeId, checkIn, checkOut);
+        String key = holdRequestKeyCacheKey(holdRequestKey, roomTypeId, checkIn, checkOut);
         redisRepository.setValue(key, holdId, ttl);
     }
 
     public void delete(
-            String idempotentKey,
+            String holdRequestKey,
             Long roomTypeId,
             LocalDate checkIn,
             LocalDate checkOut
     ) {
-        String key = idempotentKey(idempotentKey, roomTypeId, checkIn, checkOut);
+        String key = holdRequestKeyCacheKey(holdRequestKey, roomTypeId, checkIn, checkOut);
         redisRepository.deleteValue(key);
     }
 
-    private String idempotentKey(String key, Long roomTypeId, LocalDate checkIn, LocalDate checkOut) {
-        return String.format(HOLD_IDEMPOTENT_FORMAT, key, roomTypeId, checkIn, checkOut);
+    private String holdRequestKeyCacheKey(String holdRequestKey, Long roomTypeId, LocalDate checkIn, LocalDate checkOut) {
+        return String.format(HOLD_REQUEST_KEY_FORMAT, holdRequestKey, roomTypeId, checkIn, checkOut);
     }
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/dto/CreateReservationHoldRequest.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/dto/CreateReservationHoldRequest.java
@@ -25,8 +25,8 @@ public record CreateReservationHoldRequest(
         @Min(value = 1, message = "최소 1명 이상의 예약 인원을 입력해주세요.")
         Integer capacity,
 
-        @NotNull(message = "멱등 키를 입력해주세요.")
-        @Pattern(regexp = "^[0-9a-fA-F-]{36}$", message = "유효한 멱등 키(UUID) 형식이 아닙니다.")
-        String idempotencyKey
+        @NotNull(message = "요청 키를 입력해주세요.")
+        @Pattern(regexp = "^[0-9a-fA-F-]{36}$", message = "유효한 요청 키(UUID) 형식이 아닙니다.")
+        String holdRequestKey
 ) {
 }

--- a/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/dto/CreateReservationHoldRequest.java
+++ b/reservation-api/src/main/java/com/f1v3/reservation/api/reservation/dto/CreateReservationHoldRequest.java
@@ -27,6 +27,6 @@ public record CreateReservationHoldRequest(
 
         @NotNull(message = "멱등 키를 입력해주세요.")
         @Pattern(regexp = "^[0-9a-fA-F-]{36}$", message = "유효한 멱등 키(UUID) 형식이 아닙니다.")
-        String idempotentKey
+        String idempotencyKey
 ) {
 }

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -73,7 +73,7 @@ public enum ErrorCode {
     RESERVATION_HOLD_FORBIDDEN(ErrorStatus.FORBIDDEN, 8004, "해당 임시 예약에 접근할 수 없습니다."),
     RESERVATION_LOCK_TIMEOUT(ErrorStatus.CONFLICT, 8005, "동일 일정 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
     RESERVATION_HOLD_EXPIRED(ErrorStatus.BAD_REQUEST, 8006, "임시 예약이 만료되었습니다."),
-    RESERVATION_HOLD_KEY_CONFLICT(ErrorStatus.CONFLICT, 8007, "이미 사용된 멱등 키입니다."),
+    RESERVATION_HOLD_REQUEST_KEY_CONFLICT(ErrorStatus.CONFLICT, 8007, "이미 사용된 요청 키입니다."),
     RESERVATION_MAX_STAY_EXCEEDED(ErrorStatus.BAD_REQUEST, 8008, "최대 숙박 일을 초과했습니다. 30일 이내로 예약해주세요."),
 
 

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/api/error/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode {
     RESERVATION_LOCK_TIMEOUT(ErrorStatus.CONFLICT, 8005, "동일 일정 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
     RESERVATION_HOLD_EXPIRED(ErrorStatus.BAD_REQUEST, 8006, "임시 예약이 만료되었습니다."),
     RESERVATION_HOLD_KEY_CONFLICT(ErrorStatus.CONFLICT, 8007, "이미 사용된 멱등 키입니다."),
+    RESERVATION_MAX_STAY_EXCEEDED(ErrorStatus.BAD_REQUEST, 8008, "최대 숙박 일을 초과했습니다. 30일 이내로 예약해주세요."),
 
 
     /*

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/config/RedissonConfig.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/config/RedissonConfig.java
@@ -18,14 +18,12 @@ import org.springframework.context.annotation.Configuration;
 public class RedissonConfig {
 
     private static final String REDISSON_HOST_PREFIX = "redis://";
-    private static final int LOCK_WATCHDOG_TIMEOUT_MILLIS = 15000;
     private final RedisProperties redisProperties;
 
     @Bean
     public RedissonClient redissonClient() {
         Config config = new Config();
-        config.setLockWatchdogTimeout(LOCK_WATCHDOG_TIMEOUT_MILLIS)
-                .useSingleServer()
+        config.useSingleServer()
                 .setAddress(REDISSON_HOST_PREFIX + redisProperties.getHost() + ":" + redisProperties.getPort())
                 .setPassword(redisProperties.getPassword());
 

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/domain/reservation/ReservationHold.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/domain/reservation/ReservationHold.java
@@ -14,7 +14,7 @@ public record ReservationHold(
         LocalDate checkIn,
         LocalDate checkOut,
         Long userId,
-        String idempotentKey,
+        String idempotencyKey,
         LocalDateTime createdAt,
         LocalDateTime expiredAt
 ) {

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/domain/reservation/ReservationHold.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/domain/reservation/ReservationHold.java
@@ -14,7 +14,7 @@ public record ReservationHold(
         LocalDate checkIn,
         LocalDate checkOut,
         Long userId,
-        String idempotencyKey,
+        String holdRequestKey,
         LocalDateTime createdAt,
         LocalDateTime expiredAt
 ) {

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/redis/RedisKey.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/redis/RedisKey.java
@@ -13,7 +13,7 @@ public final class RedisKey {
      */
     public static final String HOLD_KEY_FORMAT = "reservation:hold:%s";
     public static final String HOLD_IDX_FORMAT = "reservation:hold:idx:%d:%d:%s:%s";
-    public static final String HOLD_IDEMPOTENT_FORMAT = "reservation:hold:idempotent:%s:%d:%s:%s";
+    public static final String HOLD_REQUEST_KEY_FORMAT = "reservation:hold:request-key:%s:%d:%s:%s";
     public static final String HOLD_COUNT_FORMAT = "reservation:hold:count:%d:%s";
 
     /**

--- a/reservation-common/src/main/java/com/f1v3/reservation/common/redis/RedisRepository.java
+++ b/reservation-common/src/main/java/com/f1v3/reservation/common/redis/RedisRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Redis 레포지토리 클래스
@@ -23,6 +24,10 @@ public class RedisRepository {
 
     public Boolean setIfAbsent(String key, String value, Duration timeout) {
         return redisTemplate.opsForValue().setIfAbsent(key, value, timeout);
+    }
+
+    public List<String> getMultiValues(List<String> keys) {
+        return redisTemplate.opsForValue().multiGet(keys);
     }
 
     public String getValue(String key) {


### PR DESCRIPTION
## 연관 이슈

resolve #26 

## 작업 내용

- 락 시간 관리 변경: watchdog &rarr; 해제 시간(leaseTime) 명시 + 모니터링을 통해 변경하도록 수정 
- 가계약 관련 캐시 데이터 조회 및 제거 로직 개선 